### PR TITLE
Cambio de múltiplo

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,9 +96,9 @@
 				<button aria-label="Color Negro, Valor 1Ω" class="band-btn active" attr-value="0" style="background:#000;" aria-pressed="true">1Ω</button>
 				<button aria-label="Color Marrón, Valor 10Ω" class="band-btn" attr-value="1" style="background:#724729;">10Ω</button>
 				<button aria-label="Color Rojo, Valor 100Ω" class="band-btn" attr-value="2" style="background:#ba2525;">100Ω</button>
-				<button aria-label="Color Naranja, Valor 1 Kilo Ω" class="band-btn" attr-value="3" style="background:#e08224;">1KΩ</button>
-				<button aria-label="Color Amarillo, Valor 10 Kilo Ω" class="band-btn" attr-value="4" style="background:#ffec00; color: #000;">10KΩ</button>
-				<button aria-label="Color Verde, Valor 100 Kilo Ω" class="band-btn" attr-value="5" style="background:#4b8241;">100KΩ</button>
+				<button aria-label="Color Naranja, Valor 1 Kilo Ω" class="band-btn" attr-value="3" style="background:#e08224;">1kΩ</button>
+				<button aria-label="Color Amarillo, Valor 10 Kilo Ω" class="band-btn" attr-value="4" style="background:#ffec00; color: #000;">10kΩ</button>
+				<button aria-label="Color Verde, Valor 100 Kilo Ω" class="band-btn" attr-value="5" style="background:#4b8241;">100kΩ</button>
 				<button aria-label="Color Azul, Valor 1 Mega Ω" class="band-btn" attr-value="6" style="background:#434a9b;">1MΩ</button>
 				<div class="break5"></div>
 				<button aria-label="Color Violeta, Valor 10 Mega Ω" class="band-btn" attr-value="7" style="background:#6f4d87;">10MΩ</button>
@@ -281,4 +281,5 @@
 <script type="text/javascript" src="assets/js/main.js"></script>
 <script type="text/javascript" src="assets/js/help.js"></script>
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -191,21 +191,21 @@
 					<td>Naranja</td>
 					<td>3</td>
 					<td>3</td>
-					<td>1KΩ</td>
+					<td>1kΩ</td>
 					<td>0.05%</td>
 				</tr>
 				<tr style="background: #ffec00; color: #000;">
 					<td>Amarillo</td>
 					<td>4</td>
 					<td>4</td>
-					<td>10KΩ</td>
+					<td>10kΩ</td>
 					<td>0.02%</td>
 				</tr>
 				<tr style="background: #4b8241;">
 					<td>Verde</td>
 					<td>5</td>
 					<td>5</td>
-					<td>100KΩ</td>
+					<td>100kΩ</td>
 					<td>0.5%</td>
 				</tr>
 				<tr style="background: #434a9b;">


### PR DESCRIPTION
En el SI se usa k para miles, ya que K se confunde con Kelvin.
Fixes #1 